### PR TITLE
feat(config): add bank slip type

### DIFF
--- a/functions/ecom.config.js
+++ b/functions/ecom.config.js
@@ -256,6 +256,16 @@ const app = {
             format: 'uri',
             title: 'Ícone',
             description: 'Ícone customizado para a forma de pagamento, URL da imagem'
+          },
+          bankSlipType: {
+            type: 'string',
+            enum: [
+              'bank_slip',
+              'bank_slip_yapay'
+            ],
+            default: 'bank_slip_yapay',
+            title: 'Escolha o tipo de boleto utilizado',
+            description: 'Caso utilize Yapay, deverar selecionar a opçao com o descritivo referente, caso seja qualquer outra modalidade de boleto, deverá ser a outra opção'
           }
         },
         title: 'Boleto bancário',

--- a/functions/ecom.config.js
+++ b/functions/ecom.config.js
@@ -257,15 +257,10 @@ const app = {
             title: 'Ícone',
             description: 'Ícone customizado para a forma de pagamento, URL da imagem'
           },
-          bankSlipType: {
-            type: 'string',
-            enum: [
-              'bank_slip',
-              'bank_slip_yapay'
-            ],
-            default: 'bank_slip_yapay',
-            title: 'Escolha o tipo de boleto utilizado',
-            description: 'Caso utilize Yapay, deverar selecionar a opçao com o descritivo referente, caso seja qualquer outra modalidade de boleto, deverá ser a outra opção'
+          is_yapay: {
+            type: 'boolean',
+            default: false,
+            title: 'Boleto Yapay'
           }
         },
         title: 'Boleto bancário',

--- a/functions/routes/ecom/modules/create-transaction.js
+++ b/functions/routes/ecom/modules/create-transaction.js
@@ -81,7 +81,7 @@ exports.post = ({ appSdk, admin }, req, res) => {
     vindiBill.installments = installmentsNumber
   } else {
     // banking billet
-    vindiBill.payment_method_code = 'bank_slip'
+    vindiBill.payment_method_code = config.banking_billet.bankSlipType ? config.banking_billet.bankSlipType : 'bank_slip'
   }
 
   axiosVindi({

--- a/functions/routes/ecom/modules/create-transaction.js
+++ b/functions/routes/ecom/modules/create-transaction.js
@@ -81,7 +81,7 @@ exports.post = ({ appSdk, admin }, req, res) => {
     vindiBill.installments = installmentsNumber
   } else {
     // banking billet
-    vindiBill.payment_method_code = config.banking_billet.bankSlipType ? config.banking_billet.bankSlipType : 'bank_slip'
+    vindiBill.payment_method_code = config.banking_billet.is_yapay ? 'bank_slip_yapay' : 'bank_slip'
   }
 
   axiosVindi({


### PR DESCRIPTION
After acquisition by locaweb, Vindi instead of just insert Yapay bank slip at possibilities with this payment method, Vindi create another payment method with code bank_slip_yapay, so if our client use yapay banking billet, he need to select bank_slip_yapay, if he use Santander, Bradesco, Caixa or  another one, he select only bank_slip